### PR TITLE
Fix check for non matching akka and akka http versions

### DIFF
--- a/src/main/scala/com/markatta/akka/sbtvc/AkkaVersionCheckPlugin.scala
+++ b/src/main/scala/com/markatta/akka/sbtvc/AkkaVersionCheckPlugin.scala
@@ -106,7 +106,7 @@ object AkkaVersionCheckPlugin extends AutoPlugin {
 
 
 
-  private def verifyAkkaHttpAkkaRequirement(akkaHttpVersion: VersionNumber, akkaVersion: VersionNumber): Unit = {
+  private def verifyAkkaHttpAkkaRequirement(akkaVersion: VersionNumber, akkaHttpVersion: VersionNumber): Unit = {
     if (akkaHttpVersion.matchesSemVer(SemanticSelector("10.1")) &&
       akkaVersion.matchesSemVer(SemanticSelector("<2.5"))) {
       throw new MessageOnlyException(s"Akka HTTP requires Akka 2.5 or later but was $akkaVersion")

--- a/src/sbt-test/sbt-akka-version-check/http-mismatch/build.sbt
+++ b/src/sbt-test/sbt-akka-version-check/http-mismatch/build.sbt
@@ -3,6 +3,13 @@ scalaVersion := "2.12.1"
 
 // Akka http 10.1.x requires at least Akka 2.5
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.4.26",
+  "com.typesafe.akka" %% "akka-actor" % "2.4.20",
   "com.typesafe.akka" %% "akka-http" % "10.1.0",
 )
+
+TaskKey[Unit]("check") := {
+  val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
+  val last: String  = IO.read(lastLog)
+  if (!last.contains("Akka HTTP requires Akka 2.5 or later but was 2.4.20"))
+    sys.error("expected mention of non matching Akka and Akka HTTP versions")
+}

--- a/src/sbt-test/sbt-akka-version-check/http-mismatch/test
+++ b/src/sbt-test/sbt-akka-version-check/http-mismatch/test
@@ -1,1 +1,2 @@
 -> checkAkkaModuleVersions
+> check


### PR DESCRIPTION
Applying this PR will fix the check for non-matching Akka and Akka HTTP versions:
- the parameters were reversed (or they were reversed in the call to the method).
- the scripted test threw an error, but for different reasons (Akka 2.4.26 doesn't exist).